### PR TITLE
Update Step18.md: The "commandName" property has been deprecated since 4.3

### DIFF
--- a/Step18.md
+++ b/Step18.md
@@ -515,7 +515,7 @@ logging.level.org.springframework.web=INFO
 
 <body>
 	<div class="container">
-		<form:form method="post" commandName="todo">
+		<form:form method="post" modelAttribute="todo">
 			<fieldset class="form-group">
 				<form:label path="desc">Description</form:label> 
 				<form:input path="desc" type="text"


### PR DESCRIPTION
The "commandName" property has been deprecated since 4.3 (which is unfortunately hard to notice in a JSP) and removed in 5.0. Instead, you should be using "modelAttribute" which has been around for many years already.

I'll add a corresponding note to https://github.com/spring-projects/spring-framework/wiki/Migrating-to-Spring-Framework-5.x